### PR TITLE
Fixing create_pcdb error when FASTA header is missing OX= taxonomy

### DIFF
--- a/proteoclade/pcdb.py
+++ b/proteoclade/pcdb.py
@@ -248,8 +248,8 @@ def _producer(fasta_directory, production_queue):
                         seq += line.strip()
 
                 fasta_entry_check(header, seq) #For last entry
-        if organisms_missed:
-            print(f'{organisms_missed} skipped entries from {file} due to ommitting OX= in header.')
+            if organisms_missed:
+                print(f'{organisms_missed} skipped entries from {file} due to ommitting OX= in header.')
                 
                                             
 def _worker(input_queue, output_queue, db_params, reverse):

--- a/proteoclade/pcdb.py
+++ b/proteoclade/pcdb.py
@@ -249,7 +249,7 @@ def _producer(fasta_directory, production_queue):
 
                 fasta_entry_check(header, seq) #For last entry
             if organisms_missed:
-                print(f'{organisms_missed} skipped entries from {file} due to ommitting OX= in header.')
+                print(f'{organisms_missed} skipped entries from {file} due to omitting OX= in header.')
                 
                                             
 def _worker(input_queue, output_queue, db_params, reverse):


### PR DESCRIPTION
OX= missing in FASTA header caused a crash in the function responsible for reading in sequencing data. This has now been resolved, and some more informative messages included